### PR TITLE
pin murmurhash3 to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - pin murmurhash3 to 0.1.6 [#16](https://github.com/logstash-plugins/logstash-filter-anonymize/pull/16)
+
 ## 3.0.6
   - Update gemspec summary
 

--- a/logstash-filter-anonymize.gemspec
+++ b/logstash-filter-anonymize.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-anonymize'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Replaces field values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-anonymize.gemspec
+++ b/logstash-filter-anonymize.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'murmurhash3'
+  s.add_runtime_dependency 'murmurhash3', "= 0.1.6"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'
 end


### PR DESCRIPTION
murmurhash3-ruby has released 0.1.7 but didn't publish java version. As the issue didn't get a response for half a year, this commit pin murmurhash3 to 0.1.6

Related: 
https://github.com/funny-falcon/murmurhash3-ruby/issues/11
https://github.com/elastic/logstash/issues/11941