### PR TITLE
Replace Fixnum with Integer for Ruby 3.2+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.8
+  - Fix: replace deprecated `Fixnum` constant with `Integer` for Ruby 3.2+ (JRuby 10) compatibility [#17](https://github.com/logstash-plugins/logstash-filter-anonymize/pull/17)
+
 ## 3.0.7
   - pin murmurhash3 to 0.1.6 [#16](https://github.com/logstash-plugins/logstash-filter-anonymize/pull/16)
 

--- a/lib/logstash/filters/anonymize.rb
+++ b/lib/logstash/filters/anonymize.rb
@@ -62,7 +62,7 @@ class LogStash::Filters::Anonymize < LogStash::Filters::Base
 
   def anonymize_murmur3(value)
     case value
-    when Fixnum
+    when Integer
       MurmurHash3::V32.int_hash(value)
     when String
       MurmurHash3::V32.str_hash(value)

--- a/logstash-filter-anonymize.gemspec
+++ b/logstash-filter-anonymize.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-anonymize'
-  s.version         = '3.0.7'
+  s.version         = '3.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Replaces field values with a consistent hash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Summary
- Replace `Fixnum` with `Integer` in `anonymize_murmur3` case statement

`Fixnum` was unified into `Integer` in Ruby 2.4, and the `Fixnum` constant alias was removed in Ruby 3.2 (JRuby 10). Using `Fixnum` raises `NameError: uninitialized constant Fixnum` at runtime.